### PR TITLE
Diary API 반환 타입 변경 및 Diary 컬럼 추가

### DIFF
--- a/backend/src/main/java/org/nexters/cultureland/api/ApiExceptionAdvice.java
+++ b/backend/src/main/java/org/nexters/cultureland/api/ApiExceptionAdvice.java
@@ -1,9 +1,8 @@
 package org.nexters.cultureland.api;
 
+import org.nexters.cultureland.common.ResponseMessage;
 import org.nexters.cultureland.common.excepion.NotFoundResouceException;
-import org.nexters.cultureland.message.ErrorMessage;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -13,10 +12,11 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 public class ApiExceptionAdvice {
 
     @ExceptionHandler({NotFoundResouceException.class})
-    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ResponseBody
-    public ResponseEntity<ErrorMessage> handleNotFoundException(NotFoundResouceException exception) {
-        ErrorMessage errorMessage = new ErrorMessage(exception.getMessage());
-        return new ResponseEntity<>(errorMessage, HttpStatus.NOT_FOUND);
+    public ResponseMessage handleNotFoundException(NotFoundResouceException exception) {
+        ResponseMessage responseMessage = new ResponseMessage(exception.getMessage(), 400, null);
+
+        return responseMessage;
     }
 }

--- a/backend/src/main/java/org/nexters/cultureland/api/diary/DiaryDto.java
+++ b/backend/src/main/java/org/nexters/cultureland/api/diary/DiaryDto.java
@@ -9,10 +9,17 @@ import lombok.Setter;
 @NoArgsConstructor
 public class DiaryDto {
     private String title;
+    private String sometime;
+    private String place;
+    private String withWho;
     private String content;
 
-    public DiaryDto(final String title, final String content) {
+    public DiaryDto(final String title, final String sometime,
+                    final String place, final String withWho, final String content) {
         this.title = title;
+        this.sometime = sometime;
+        this.place = place;
+        this.withWho = withWho;
         this.content = content;
     }
 }

--- a/backend/src/main/java/org/nexters/cultureland/api/diary/controller/DiaryController.java
+++ b/backend/src/main/java/org/nexters/cultureland/api/diary/controller/DiaryController.java
@@ -4,6 +4,7 @@ import org.nexters.cultureland.api.diary.Diaries;
 import org.nexters.cultureland.api.diary.DiaryDto;
 import org.nexters.cultureland.api.diary.service.DiaryService;
 import org.nexters.cultureland.api.diary.model.Diary;
+import org.nexters.cultureland.common.ResponseMessage;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,7 +12,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping(path = "/users/{userId}/diaries")
+@RequestMapping(path = "/diaries")
 public class DiaryController {
 
     private final DiaryService diaryService;
@@ -21,34 +22,48 @@ public class DiaryController {
     }
 
     @GetMapping
-    public ResponseEntity<Diaries> readAllUserDiaries() {
-        return ResponseEntity.ok(diaryService.fetchDiaries());
+    public ResponseMessage readAllUserDiaries() {
+        Diaries diaries = diaryService.fetchDiaries();
+
+        ResponseMessage responseMessage = ResponseMessage.getOkResponseMessage();
+        responseMessage.setMessage(diaries);
+        return responseMessage;
     }
 
     @PostMapping
-    public ResponseEntity<Diary> createUserDiary(@PathVariable Long userId, DiaryDto diaryDto) {
+    public ResponseMessage createUserDiary(DiaryDto diaryDto) {
         Diary diary = diaryService.create(diaryDto);
 
-        String location = String.format("/users/%d/diaries/%d", userId, diary.getId());
-        MultiValueMap<String, String> headers = new HttpHeaders();
-        headers.add("Location", location);
+        ResponseMessage responseMessage = ResponseMessage.getOkResponseMessage();
+        responseMessage.setMessage(diary);
 
-        return new ResponseEntity<>(diary, headers, HttpStatus.CREATED);
+        return responseMessage;
     }
 
     @GetMapping("/{diaryId}")
-    public ResponseEntity<Diary> readUserDiary(@PathVariable Long userId, @PathVariable Long diaryId) {
-        return new ResponseEntity<>(diaryService.getDiaryOf(diaryId), HttpStatus.OK);
+    public ResponseMessage readUserDiary(@PathVariable Long diaryId) {
+        Diary diary = diaryService.getDiaryOf(diaryId);
+
+        ResponseMessage responseMessage = ResponseMessage.getOkResponseMessage();
+        responseMessage.setMessage(diary);
+        return responseMessage;
     }
 
     @PutMapping("/{diaryId}")
-    public ResponseEntity<Diary> updateUserDiary(@PathVariable Long userId, @PathVariable Long diaryId, DiaryDto diaryDto) {
-        return new ResponseEntity<>(diaryService.updateDiaryOf(diaryId, diaryDto), HttpStatus.OK);
+    public ResponseMessage updateUserDiary(@PathVariable Long diaryId, DiaryDto diaryDto) {
+        Diary diary = diaryService.updateDiaryOf(diaryId, diaryDto);
+
+        ResponseMessage responseMessage = ResponseMessage.getOkResponseMessage();
+        responseMessage.setMessage(diary);
+        return responseMessage;
     }
 
     @DeleteMapping("/{diaryId}")
-    public ResponseEntity delteteUserDiary(@PathVariable Long userId, @PathVariable Long diaryId) {
+    public ResponseMessage deleteUserDiary(@PathVariable Long diaryId) {
         diaryService.deleteDiaryOf(diaryId);
-        return ResponseEntity.status(200).build();
+
+        ResponseMessage responseMessage = ResponseMessage.getOkResponseMessage();
+        responseMessage.setMessage("성공적으로 삭제되었습니다.");
+        return responseMessage;
     }
 }

--- a/backend/src/main/java/org/nexters/cultureland/api/diary/model/Diary.java
+++ b/backend/src/main/java/org/nexters/cultureland/api/diary/model/Diary.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.nexters.cultureland.api.diary.DiaryDto;
+import org.nexters.cultureland.api.user.model.User;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -17,13 +18,22 @@ public class Diary {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Column(length = 30, nullable = false)
     private String title;
-
+    @Column(nullable = false)
+    private LocalDateTime sometime;
+    @Column(nullable = false)
+    private String place;
+    @Column(nullable = false)
+    private String withWho;
     @Lob
+    @Column(nullable = false)
     private String content;
-
     @Column(name = "CREATED_BY")
     private LocalDateTime createdBy = LocalDateTime.now();
+    @ManyToOne(cascade = CascadeType.ALL)
+    @JoinColumn(foreignKey = @ForeignKey(name = "DIARY_USER_FK"), nullable = false)
+    private User user;
 
     @Builder
     private Diary(final Long id, final String title, final String content) {
@@ -32,8 +42,22 @@ public class Diary {
         this.content = content;
     }
 
+    @Builder
+    private Diary(final Long id, final String title, final LocalDateTime sometime, final String where, final String withWho, final String content, final User user) {
+        this.id = id;
+        this.title = title;
+        this.sometime = sometime;
+        this.place = where;
+        this.withWho = withWho;
+        this.content = content;
+        this.user = user;
+    }
+
     public void update(final DiaryDto diaryDto) {
         title = diaryDto.getTitle();
+        sometime = LocalDateTime.parse(diaryDto.getSometime());
+        place = diaryDto.getPlace();
+        withWho = diaryDto.getWithWho();
         content = diaryDto.getContent();
     }
 }

--- a/backend/src/test/java/org/nexters/cultureland/api/diary/DiaryControllerTest.java
+++ b/backend/src/test/java/org/nexters/cultureland/api/diary/DiaryControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -25,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(DiaryController.class)
 public class DiaryControllerTest {
 
-    private static final String BASE_URL = "/users/1/diaries";
+    private static final String BASE_URL = "/diaries";
 
     @Autowired
     private MockMvc mockMvc;
@@ -41,6 +42,9 @@ public class DiaryControllerTest {
                 .id(1L)
                 .title("title")
                 .content("content")
+                .sometime(LocalDateTime.now())
+                .where("강남역 메리츠타워")
+                .withWho("컬쳐랜드")
                 .build();
     }
 
@@ -53,29 +57,30 @@ public class DiaryControllerTest {
         ).andDo(print())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("diaries.[0].id").value(1L))
-                .andExpect(jsonPath("diaries.[0].title").value("title"))
-                .andExpect(jsonPath("diaries.[0].content").value("content"));
+                .andExpect(jsonPath("message.diaries.[0].id").value(1L))
+                .andExpect(jsonPath("message.diaries.[0].title").value("title"))
+                .andExpect(jsonPath("message.diaries.[0].content").value("content"));
     }
 
     @Test
     void diary_생성() throws Exception {
         String title = "title";
         String content = "content";
-        Diary createDiary = Diary.builder()
-                .id(1L)
-                .title(title)
-                .content(content)
-                .build();
 
-        given(diaryService.create(any(DiaryDto.class))).willReturn(createDiary);
+        given(diaryService.create(any(DiaryDto.class))).willReturn(diary);
 
         mockMvc.perform(post(BASE_URL)
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .param("title", title)
                 .param("content", content)
+                .param("when", "2019-08-03")
+                .param("where", "강남역 메리츠타워")
+                .param("with", "컬쳐랜드")
         ).andDo(print())
-                .andExpect(status().isCreated());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("message.id").value(1L))
+                .andExpect(jsonPath("message.title").value("title"))
+                .andExpect(jsonPath("message.content").value("content"));
     }
 
     @Test
@@ -87,9 +92,9 @@ public class DiaryControllerTest {
         ).andDo(print())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(1L))
-                .andExpect(jsonPath("$.title").value("title"))
-                .andExpect(jsonPath("$.content").value("content"));
+                .andExpect(jsonPath("message.id").value(1L))
+                .andExpect(jsonPath("message.title").value("title"))
+                .andExpect(jsonPath("message.content").value("content"));
     }
 
     @Test
@@ -101,8 +106,8 @@ public class DiaryControllerTest {
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
         ).andDo(print())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value(errorMessage));
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("error").value(errorMessage));
     }
 
     @Test

--- a/backend/src/test/java/org/nexters/cultureland/api/diary/DiaryServiceTest.java
+++ b/backend/src/test/java/org/nexters/cultureland/api/diary/DiaryServiceTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,6 +34,9 @@ public class DiaryServiceTest {
                 .id(1L)
                 .title("title")
                 .content("content")
+                .sometime(LocalDateTime.now())
+                .where("강남역 메리츠타워")
+                .withWho("컬쳐랜드")
                 .build();
 
         given(diaryRepository.findById(1L)).willReturn(Optional.ofNullable(testDiary));
@@ -41,10 +45,16 @@ public class DiaryServiceTest {
         // when
         String updateTitle = "제목";
         String updateContent = "내용";
-        Diary updateDiary = diaryService.updateDiaryOf(1L, new DiaryDto(updateTitle, updateContent));
+        String updateWhen = "2019-08-03T00:00:00";
+        String updateWhere = "공덕역 창업센터";
+        String updateWith = "넥스터즈";
+        Diary updateDiary = diaryService.updateDiaryOf(1L, new DiaryDto(updateTitle, updateWhen, updateWhere, updateWith, updateContent));
 
         // then
         assertThat(updateDiary.getTitle()).isEqualTo(updateTitle);
         assertThat(updateDiary.getContent()).isEqualTo(updateContent);
+        assertThat(updateDiary.getSometime()).isEqualTo(LocalDateTime.parse(updateWhen));
+        assertThat(updateDiary.getPlace()).isEqualTo(updateWhere);
+        assertThat(updateDiary.getWithWho()).isEqualTo(updateWith);
     }
 }


### PR DESCRIPTION
- API 반환 타입 ResponseMessage로 변경
- 기록 추가 시 어디서, 누구와, 언제 항목이 있기 때문에 해당 항목 추가
- 일단은 Diary 요청 url에 user 제외 (/diary/**)

변수명 추천 받아요! `where`, `when`, `with`로 정했다가 SQL 예약어라 오류가 나서 일단은 `place`, `withWho`, `sometime`으로 했습니다.