### PR TITLE
좋아요된 기록 조회 구현, 월별 요약 정보 중 default 이미지 추가

### DIFF
--- a/backend/src/main/java/org/nexters/cultureland/api/dto/Category.java
+++ b/backend/src/main/java/org/nexters/cultureland/api/dto/Category.java
@@ -1,7 +1,7 @@
 package org.nexters.cultureland.api.dto;
 
 public enum Category {
-    MUSICAL, CONCERT, PLAY, EXHIBITION, ETC, NONE;
+    MUSICAL, CONCERT, PLAY, EXHIBITION, LIKE, ETC, NONE;
 
     public static Category getCategoryFrom(String input) {
         for (Category category : Category.values()) {

--- a/backend/src/main/java/org/nexters/cultureland/api/dto/DiaryCountDto.java
+++ b/backend/src/main/java/org/nexters/cultureland/api/dto/DiaryCountDto.java
@@ -12,10 +12,12 @@ public class DiaryCountDto {
 
     private String monthTime;
     private int count;
+    private String imageUrl;
 
     @Builder
-    private DiaryCountDto(final String monthTime, final int count) {
+    public DiaryCountDto(final String monthTime, final int count, final String imageUrl) {
         this.monthTime = monthTime;
         this.count = count;
+        this.imageUrl = imageUrl;
     }
 }

--- a/backend/src/main/java/org/nexters/cultureland/api/repo/DiaryRepository.java
+++ b/backend/src/main/java/org/nexters/cultureland/api/repo/DiaryRepository.java
@@ -10,17 +10,23 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     @Query(value = "select date_format(sometime,'%m') as d, count(*) from diary where user_seq = :userId and year(sometime) = :year group by d", nativeQuery = true)
     List<Object[]> countByUser(@Param("userId") Long userId, @Param("year") String year);
 
+    @Query(value = "select image_url from diary where user_seq = :userId and date_format(sometime, '%Y%m') = :date order by sometime desc limit 1", nativeQuery = true)
+    Optional<String> findDefaultImageByMonth(@Param("userId") Long UserId, @Param("date") String date);
+
     @Query("select d.culture.cultureName, count(d.culture) from Diary d where d.user.seq = :userId group by d.culture.id")
     List<Object[]> countByCategories(@Param("userId") Long userId);
 
     @Query("select count(d) from Diary d where d.favorite = true and d.user.seq = :userId")
     Long countByUserFavoriteDiary(@Param("userId") Long userId);
+
+    Page<DiaryDto> findByFavoriteIsTrue(Pageable pageable);
 
     Page<DiaryDto> findByCulture_CultureNameAndUser(String cultureName, User user, Pageable pageable);
 

--- a/backend/src/main/java/org/nexters/cultureland/api/service/RepositoryService.java
+++ b/backend/src/main/java/org/nexters/cultureland/api/service/RepositoryService.java
@@ -39,6 +39,10 @@ public class RepositoryService {
         User user = findUser(userId);
 
         if (category != null) {
+            if (category == Category.LIKE) {
+                return diaryRepository.findByFavoriteIsTrue(pageable);
+            }
+
             return diaryRepository.findByCulture_CultureNameAndUser(category.name(), user, pageable);
         } else if (date != null) {
             Page<Diary> diaryPage = diaryRepository.findByUserAndSometime(date, user.getSeq(), pageable);
@@ -113,11 +117,13 @@ public class RepositoryService {
         User user = findUser(userId);
         List<Object[]> queryResult = diaryRepository.countByUser(user.getSeq(), year);
 
+
         return queryResult.stream()
                 .map((result) ->
                         DiaryCountDto.builder()
                                 .monthTime((String) result[0])
                                 .count(((BigInteger) result[1]).intValue())
+                                .imageUrl(diaryRepository.findDefaultImageByMonth(user.getSeq(), year + result[0]).orElse(""))
                                 .build()
                 ).collect(Collectors.toList());
     }


### PR DESCRIPTION
좋아요 기록은 Spring Data JPA가 지원하는 쿼리 메서드로 구현하였고
이미지 추가는 쿼리 하나로 해결되지 않아 해당 월에 가장 최신의 url을 가져오는 native query로 해결했습니다.